### PR TITLE
fix: filter submissions by date in fetchSubmissionsForDate #17 team T188

### DIFF
--- a/src/services/leetcode.service.js
+++ b/src/services/leetcode.service.js
@@ -259,11 +259,21 @@ const fetchSubmissionsForDate = async (
   date,
   sessionData = null
 ) => {
-
-  return await fetchUserSubmissions(
+  const submissions = await fetchUserSubmissions(
     leetcodeUsername,
     sessionData
   );
+
+  // Filter submissions to only include those from the specified date
+  const startOfDay = new Date(date);
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(date);
+  endOfDay.setHours(23, 59, 59, 999);
+
+  return submissions.filter((sub) => {
+    const subDate = new Date(parseInt(sub.timestamp) * 1000);
+    return subDate >= startOfDay && subDate <= endOfDay;
+  });
 };
 
 /**


### PR DESCRIPTION
Team number: Team 188
## Description
Fixes #17

The [fetchSubmissionsForDate](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/leetcode.service.js:249:0-276:2) function accepted a [date](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/evaluation.service.js:250:0-279:2) parameter but never used it — it simply forwarded the call to [fetchUserSubmissions()](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/leetcode.service.js:90:0-160:2) without any date filtering. This caused the daily evaluation to check **all** submissions instead of only those from the target date.

## Changes
- Added date boundary calculation (`startOfDay` / `endOfDay`) using the provided [date](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/evaluation.service.js:250:0-279:2) parameter
- Added `.filter()` to only return submissions whose timestamp falls within the target date

## Testing
- Verified that the date filtering correctly bounds submissions to the specified day
- Callers in [evaluation.service.js](cci:7://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/evaluation.service.js:0:0-0:0) and [leetcode.controller.js](cci:7://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/controllers/leetcode.controller.js:0:0-0:0) already pass the [date](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/code_duel_backend/Code_duel_backend/src/services/evaluation.service.js:250:0-279:2) parameter correctly