### PR TITLE
Fix/revoke jwt after password change

### DIFF
--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -2,7 +2,11 @@ const bcrypt = require("bcryptjs");
 const crypto = require("crypto");
 const { prisma } = require("../config/prisma");
 const { config } = require("../config/env");
-const { generateToken, decodeToken } = require("../utils/jwt");
+const {
+  generateToken,
+  decodeToken,
+  createPasswordVersion,
+} = require("../utils/jwt");
 const { AppError } = require("../middlewares/error.middleware");
 const logger = require("../utils/logger");
 const { logAudit } = require("../utils/auditLogger");
@@ -44,7 +48,10 @@ const register = async (userData) => {
   });
 
   // Generate JWT token
-  const token = generateToken({ userId: user.id });
+  const token = generateToken({
+    userId: user.id,
+    pwdv: createPasswordVersion(hashedPassword),
+  });
 
   logger.info(`New user registered: ${user.username} (${user.email})`);
 
@@ -91,8 +98,11 @@ const login = async (emailOrUsername, password) => {
     throw new AppError("Invalid credentials", 401);
   }
 
-  // Generate token
-  const token = generateToken({ userId: user.id });
+  // Generate JWT token
+  const token = generateToken({
+    userId: user.id,
+    pwdv: createPasswordVersion(user.password),
+  });
 
   logger.info(`User logged in: ${user.username}`);
 

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,4 +1,5 @@
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
 const { config } = require("../config/env");
 
 /**
@@ -41,8 +42,23 @@ const decodeToken = (token) => {
   return jwt.decode(token);
 };
 
+/**
+ * Derive a stable token-bound password version from the stored hash.
+ * This changes whenever password hash changes, invalidating old tokens.
+ * @param {string} passwordHash - Bcrypt password hash from database
+ * @returns {string} Password version fingerprint
+ */
+const createPasswordVersion = (passwordHash) => {
+  return crypto
+    .createHmac("sha256", config.jwtSecret)
+    .update(passwordHash)
+    .digest("hex")
+    .slice(0, 24);
+};
+
 module.exports = {
   generateToken,
   verifyToken,
   decodeToken,
+  createPasswordVersion,
 };


### PR DESCRIPTION
```md
## Team Number : Team 137

## Description
This PR fixes a session security issue where old JWT tokens remained valid after a password change.  
Now, tokens issued before password update are rejected, and users must log in again to get a new valid token.

## Related Issue
Closes #80

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement

## Changes Made
- Added password-version fingerprint support in JWT utility (`createPasswordVersion`).
- Included password version (`pwdv`) in JWT payload during register/login token creation.
- Updated authentication middleware to validate token password version against current DB password hash and reject stale tokens with `401`.

## Screenshots (if applicable)
**Before:**
N/A (backend/API security fix)

**After:**
N/A (backend/API security fix)

## Testing
- [ ] Tested on Desktop (Chrome/Firefox/Safari)
- [ ] Tested on Mobile (iOS/Android)
- [ ] Tested responsive design (different screen sizes)
- [x] No console errors or warnings
- [ ] Code builds successfully (`npm run build`)

Manual API verification (Postman):
- [x] Logged in and obtained token `T1`.
- [x] Changed password via `PUT /api/auth/profile`.
- [x] Retested old token `T1` on protected endpoint and received `401 Unauthorized`.
- [x] Logged in again with new password and verified new token works.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [ ] All TypeScript types are properly defined
- [ ] Tailwind CSS classes are used appropriately (no inline styles)
- [ ] Component is responsive across different screen sizes
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
- This is a backend-only security hardening change.
- Existing valid tokens continue to work only until password is changed; after password change, old tokens are invalidated immediately.
```